### PR TITLE
[PAN-1868] Remove misleading reference to a project

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_REPORT.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 labels: ["bug", "triage"]
-projects: ["pantos-io/4"]
 assignees:
   - pantos-io/blockchain-backend
 body:

--- a/.github/ISSUE_TEMPLATE/feature_report.yml
+++ b/.github/ISSUE_TEMPLATE/feature_report.yml
@@ -1,7 +1,6 @@
 name: Feature Request
 description: You want a new feature to be implemented.
 labels: [wishlisted]
-projects: ["pantos-io/3"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The `ci-workflows` repo is not a project itself, for this reason there is no need to reference the project id in the issue template.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

NA

## QA Instructions

The project label is no longer used.

## [optional] Are there any post deployment tasks we need to perform?
