### PR TITLE
[PAN-1880] Skip sonar analysis for forked repos

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -134,6 +134,10 @@ jobs:
           path: postgres-coverage.xml
 
   SonarCloud:
+    # SonarCloud requires the SONAR_TOKEN to be visible. For PRs
+    # coming from a forked repo this is not possible. Until we 
+    # have a workaround for this, we will skip this part.
+    if: github.event.pull_request.head.repo.name == github.repository
     runs-on: ubuntu-latest
     needs: [StaticCodeAnalysis, Format, Lint, Sort, Bandit, UnitTest]
     steps:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The `SONAR_TOKEN` required by SonarCloud to run the analysis cannot be passed for forked repos. This means that the last stage will fail. Until we have a workaround, I would simply skip this step.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

NA

## QA Instructions

_Please replace this line with instructions on how to test your changes._

Invoke the workflow from a forked repo and check that the SonarCloud operations does not run.

## [optional] Are there any post deployment tasks we need to perform?
