### PR TITLE
[PAN-1881] Sonar Analysis as an independant workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -132,27 +132,3 @@ jobs:
         with:
           name: code-coverage-postgres-report
           path: postgres-coverage.xml
-
-  # SonarCloud:
-  #   runs-on: ubuntu-latest
-  #   needs: [StaticCodeAnalysis, Format, Lint, Sort, Bandit, UnitTest]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #           submodules: recursive
-  #           token: ${{ secrets.GH_TOKEN || github.token }}
-
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: code-coverage-report
-
-  #     - uses: actions/download-artifact@v4
-  #       if: ${{ inputs.test-database }}
-  #       with:
-  #         name: code-coverage-postgres-report
-
-  #     - name: SonarCloud Scan
-  #       uses: SonarSource/sonarcloud-github-action@master
-  #       env:
-  #           GITHUB_TOKEN:  ${{ secrets.GH_TOKEN || github.token }}  # Needed to get PR information, if any
-  #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -133,26 +133,26 @@ jobs:
           name: code-coverage-postgres-report
           path: postgres-coverage.xml
 
-  SonarCloud:
-    runs-on: ubuntu-latest
-    needs: [StaticCodeAnalysis, Format, Lint, Sort, Bandit, UnitTest]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-            submodules: recursive
-            token: ${{ secrets.GH_TOKEN || github.token }}
+  # SonarCloud:
+  #   runs-on: ubuntu-latest
+  #   needs: [StaticCodeAnalysis, Format, Lint, Sort, Bandit, UnitTest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #           submodules: recursive
+  #           token: ${{ secrets.GH_TOKEN || github.token }}
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: code-coverage-report
 
-      - uses: actions/download-artifact@v4
-        if: ${{ inputs.test-database }}
-        with:
-          name: code-coverage-postgres-report
+  #     - uses: actions/download-artifact@v4
+  #       if: ${{ inputs.test-database }}
+  #       with:
+  #         name: code-coverage-postgres-report
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-            GITHUB_TOKEN:  ${{ secrets.GH_TOKEN || github.token }}  # Needed to get PR information, if any
-            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     - name: SonarCloud Scan
+  #       uses: SonarSource/sonarcloud-github-action@master
+  #       env:
+  #           GITHUB_TOKEN:  ${{ secrets.GH_TOKEN || github.token }}  # Needed to get PR information, if any
+  #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
       - uses: actions/download-artifact@v4
         if: ${{ inputs.test-database }}
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,14 +33,30 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - name: Get run ID of "Test" workflow
+        id: get-run-id
+        run: |
+          OTHER_REPO="${{ github.repository }}"
+          WF_NAME="CI"
+          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow ${WF_NAME} --json databaseId --jq .[0].databaseId`
+          echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
+          echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Download artifact from "Test" workflow
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
-          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-run-id.outputs.run-id }}
       - uses: actions/download-artifact@v4
         if: ${{ inputs.test-database }}
         with:
           name: code-coverage-postgres-report
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-run-id.outputs.run-id }}
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,50 @@
+name: Sonar
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+jobs:
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: 'Download code coverage'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "code-coverage-report"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/code-coverage-report.zip`, Buffer.from(download.data));
+      - name: 'Unzip code coverage'
+        run: unzip code-coverage-report -d coverage
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
+          run_id: ${{ github.event.workflow_run.id }}
       - uses: actions/download-artifact@v4
         if: ${{ inputs.test-database }}
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,7 +33,7 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: Get run ID of "Test" workflow
+      - name: Get run ID of parent workflow
         id: get-run-id
         run: |
           OTHER_REPO="${{ github.repository }}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,7 +1,25 @@
 name: Sonar
 on:
+  workflow_call:
+    inputs:
+      test-database:
+        required: false
+        type: boolean
+        default: false
+      database-name:
+        required: false
+        type: string
+        default: ""
+      database-user:
+        required: false
+        type: string
+        default: ""
+      database-password:
+        required: false
+        type: string
+        default: ""
   workflow_run:
-    workflows: [CI]
+    workflows: [CI shared workflow]
     types: [completed]
 jobs:
   sonar:
@@ -15,28 +33,13 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: 'Download code coverage'
-        uses: actions/github-script@v6
+      - uses: actions/download-artifact@v4
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "code-coverage-report"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/code-coverage-report.zip`, Buffer.from(download.data));
-      - name: 'Unzip code coverage'
-        run: unzip code-coverage-report -d coverage
+          name: code-coverage-report
+      - uses: actions/download-artifact@v4
+        if: ${{ inputs.test-database }}
+        with:
+          name: code-coverage-postgres-report
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,21 +6,16 @@ on:
         required: false
         type: boolean
         default: false
-      database-name:
-        required: false
-        type: string
-        default: ""
-      database-user:
-        required: false
-        type: string
-        default: ""
-      database-password:
-        required: false
-        type: string
-        default: ""
   workflow_run:
     workflows: [CI shared workflow]
     types: [completed]
+permissions:
+  actions: read
+  checks: read
+  id-token: read
+  pull-requests: read
+  repository-projects: read
+  statuses: read
 jobs:
   sonar:
     name: Sonar
@@ -33,7 +28,7 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: Get run ID of parent workflow
+      - name: Get run ID of parent CI workflow
         id: get-run-id
         run: |
           OTHER_REPO="${{ github.repository }}"
@@ -43,7 +38,7 @@ jobs:
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Download artifact from "Test" workflow
+      - name: Download artifact from CI workflow
         uses: actions/download-artifact@v4
         with:
           name: code-coverage-report


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The SonarCloud analysis requires the `SONAR_TOKEN` secret to run. Unfortunately, this makes impossible for those PRs triggered from a forked repo to run this check. This PR splits the Sonar analysis in a separated workflow that can access the mentioned secret when running in the context of a `workflow_run` when the `CI` workflow succeeds.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

NA

## QA Instructions

In order to test this PR, merge a commit on the `common` repo and wait for the Sonar action to start. 

## [optional] Are there any post deployment tasks we need to perform?
