### PR TITLE
fix: cache config of poetry

### DIFF
--- a/.github/actions/install-poetry/action.yml
+++ b/.github/actions/install-poetry/action.yml
@@ -13,7 +13,9 @@ runs:
       id: cached-poetry
       uses: actions/cache@v4
       with:
-        path: ~/.local
+        path: |
+          ~/.local
+          ~/.config
         key: poetry-0
 
     - name: Install Poetry


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If the poetry installation is restored from the cache during the CI pipeline, then the options used during the install are not used. This is due to the fact that the installation is found under ~./local and the options are under ~./config.

This results in the virtual environment in project option not being properly restored, resulting in failing pipelines

We can fix this by caching the ~./config of poetry
