### PR TITLE
[PAN-1885] Spike to evaluate hardened agents

### DIFF
--- a/.github/actions/install-poetry/action.yml
+++ b/.github/actions/install-poetry/action.yml
@@ -4,6 +4,10 @@ description: 'Set up Python and install Poetry'
 runs:
   using: composite
   steps:
+    - uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/install-poetry/action.yml
+++ b/.github/actions/install-poetry/action.yml
@@ -6,7 +6,13 @@ runs:
   steps:
     - uses: step-security/harden-runner@v2
       with:
-        egress-policy: audit
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          files.pythonhosted.org:443
+          github.com:443
+          install.python-poetry.org:443
+          pypi.org:443  
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -4,6 +4,10 @@ description: 'Install Python library dependencies using Poetry'
 runs:
   using: composite
   steps:
+    - uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - uses: pantos-io/ci-workflows/.github/actions/install-poetry@v1
     
     - name: Load cached venv

--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -6,7 +6,13 @@ runs:
   steps:
     - uses: step-security/harden-runner@v2
       with:
-        egress-policy: audit
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          files.pythonhosted.org:443
+          github.com:443
+          install.python-poetry.org:443
+          pypi.org:443  
 
     - uses: pantos-io/ci-workflows/.github/actions/install-poetry@v1
     

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -27,7 +27,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443  
       
       - uses: actions/checkout@v4
         with:
@@ -45,7 +51,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443    
       
       - uses: actions/checkout@v4
         with:
@@ -63,7 +75,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443    
       
       - uses: actions/checkout@v4
         with:
@@ -80,7 +98,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443  
       
       - uses: actions/checkout@v4
         with:
@@ -98,7 +122,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443  
       
       - uses: actions/checkout@v4
         with:
@@ -126,7 +156,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@v2
         with:
-          egress-policy: audit  
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            install.python-poetry.org:443
+            pypi.org:443  
    
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,6 +25,10 @@ jobs:
     name: Static Code Analysis
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+      
       - uses: actions/checkout@v4
         with:
             submodules: recursive
@@ -39,6 +43,10 @@ jobs:
   Format:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+      
       - uses: actions/checkout@v4
         with:
             submodules: recursive
@@ -53,6 +61,10 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+      
       - uses: actions/checkout@v4
         with:
             submodules: recursive
@@ -66,6 +78,10 @@ jobs:
   Sort:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+      
       - uses: actions/checkout@v4
         with:
             submodules: recursive
@@ -80,6 +96,10 @@ jobs:
     name: Bandit
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+      
       - uses: actions/checkout@v4
         with:
             submodules: recursive
@@ -104,6 +124,10 @@ jobs:
           - 5432:5432
 
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit  
+   
       - uses: actions/checkout@v4
         with:
             submodules: recursive

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   StaticCodeAnalysis:
     name: Static Code Analysis

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,6 +23,9 @@ jobs:
     timeout-minutes: 30
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 Collection of CI actions used by Pantos. Collections are separated by target languages.
 - Python
 
+Additional analysis:
+- Sonar
+
+GitHub runners are hardened using [Harden Runner](https://github.com/step-security/harden-runner).
+
 ## Versioning
 
 Use the following approach when introducing changes:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Enable hardened github actions using [Harden Runner](https://github.com/step-security/harden-runner).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
https://github.com/pantos-io/common/pull/16

See policy recommendations at:
https://app.stepsecurity.io/github/pantos-io/common/actions/runs/9065096467?jobid=24904871700&tab=recommendations

## QA Instructions

Check the audit information is collected and displayed as shown in https://github.com/step-security/harden-runner. The current egress policy has been defined using a bunch of runs from https://github.com/pantos-io/common/pull/16


## [optional] Are there any post deployment tasks we need to perform?

The egress policy for the sonar pipeline has not been set yet. We need a run from the main branch to get a recommendation for the egress policy.